### PR TITLE
Proper error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode/
 /target

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Command:
 ```
 Output:
 ```
-The edge set E(G) is:
-[(2, 4), (5, 1), (1, 3), (3, 4), (4, 6)]
+The edge set is:
+E(G) = [(2, 4), (5, 1), (1, 3), (3, 4), (4, 6)]
 ```
 
 ## Project stucture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,40 +1,31 @@
 //! Module containing the implementation of the inverse Prüfer algorithm.
 
 /// Calculates the edge set of a given Prüfer code.
-///
-/// # Errors
-///
-/// If the given Prüfer code is invlaid the function returns the error variant.
-/// See: [`error::InvalidPruferCode`] for more information.
-pub fn tree_edges(prufer_code: &[u64]) -> Result<Vec<(u64, u64)>, error::InvalidPruferCode> {
+pub fn tree_edges(PruferCode { code: prufer_code }: &PruferCode) -> Vec<(u64, u64)> {
     let vertecies = prufer_code.len() + 2;
     let mut vertex_set: Vec<i8> = [0].repeat(vertecies);
 
     // count the occurence of vertecies in `prufer_code`
-    for &code in prufer_code.iter() {
-        if code > vertecies as u64 {
-            return Err(error::InvalidPruferCode::new(code, prufer_code));
-        }
-
-        vertex_set[code as usize - 1] += 1;
+    for &value in prufer_code.iter() {
+        vertex_set[value as usize - 1] += 1;
     }
 
     let mut edges = Vec::with_capacity(vertecies - 1);
 
     // create edge pairs
-    for &code in prufer_code.iter() {
+    for &value in prufer_code.iter() {
         for (j, v) in vertex_set.iter_mut().enumerate() {
             if *v == 0 {
                 *v = -1;
-                edges.push((j as u64 + 1, code));
-                vertex_set[code as usize - 1] -= 1;
+                edges.push((j as u64 + 1, value));
+                vertex_set[value as usize - 1] -= 1;
                 break;
             }
         }
     }
 
     // find last two zeros in vertex set and return the corresponding vertecies
-    // (their indicies + 1)
+    // for the last edge pair
     fn create_last_pair(vertex_set: &[i8]) -> (u64, u64) {
         let res = vertex_set
             .iter()
@@ -46,68 +37,112 @@ pub fn tree_edges(prufer_code: &[u64]) -> Result<Vec<(u64, u64)>, error::Invalid
     }
 
     edges.push(create_last_pair(&vertex_set));
-    Ok(edges)
+    edges
+}
+
+/// Represents a valid Prüfer code
+///
+/// Every number in the slice is smaller or equal to the length
+/// of the code plus two.
+#[derive(Debug, PartialEq)]
+pub struct PruferCode<'a> {
+    code: &'a [u64],
+}
+
+impl<'a> TryFrom<&'a [u64]> for PruferCode<'a> {
+    type Error = error::InvalidPruferCode<'a>;
+
+    /// Validates the given Prüfer code
+    ///
+    // # Errors
+    ///
+    /// If the given Prüfer code is invlaid the function returns the error variant.
+    /// See: [`error::InvalidPruferCode`] for more information.
+    fn try_from(prufer_code: &'a [u64]) -> Result<Self, Self::Error> {
+        let n = prufer_code.len() + 2;
+        for &value in prufer_code.iter() {
+            if value == 0 {
+                return Err(error::InvalidPruferCode::ValueIsZero { code: prufer_code });
+            }
+
+            if value > n as u64 {
+                return Err(error::InvalidPruferCode::ValueTooLarge {
+                    invalid_value: value,
+                    code: prufer_code,
+                });
+            }
+        }
+
+        Ok(PruferCode { code: prufer_code })
+    }
 }
 
 /// Module for error handling.
 pub mod error {
-
     /// Describes a Prüfer code that contains an invalid element.
     ///
     /// An element is considered invalid if it is larger than the length of
-    /// the code + 2. Created by [`super::tree_edges`].
+    /// the code + 2, or is 0. Created by [`super::tree_edges`].
     #[derive(Debug, PartialEq)]
-    pub struct InvalidPruferCode<'a> {
-        invalid_value: u64,
-        code: &'a [u64],
-    }
-
-    impl<'a> InvalidPruferCode<'a> {
-        /// Constructs a new `InvalidPruferCode`.
-        pub fn new(invalid_value: u64, code: &'a [u64]) -> Self {
-            InvalidPruferCode {
-                invalid_value,
-                code,
-            }
-        }
+    pub enum InvalidPruferCode<'a> {
+        ValueTooLarge { invalid_value: u64, code: &'a [u64] },
+        ValueIsZero { code: &'a [u64] },
     }
 
     impl ToString for InvalidPruferCode<'_> {
         /// Gives a mathematical explanation of why
         /// this [`InvalidPruferCode`] was created.
         ///
-        /// # Example
+        /// # Examples
         ///
         /// ```
-        /// let res = inverse_prufer::tree_edges(&[4, 7, 3, 4]);
+        /// # use inverse_prufer::PruferCode;
+        /// let res = PruferCode::try_from([4, 7, 3, 4].as_slice());
         /// # let res = match res {
         /// #   Ok(_) => panic!(),
         /// #   Err(e) => e,
         /// # };
-        /// eprintln!("{}", res.to_string());
-        /// ```
-        /// Prints the formatted [`String`]:
-        /// ```text
-        /// Invalid value in code: 7
+        /// assert_eq!(res.to_string(),
+        /// r#"Invalid value in code: 7
         ///     SEQ = [4, 7, 3, 4]
         ///     N := |SEQ| + 2 = 6
         ///     max(SEQ) = 7
-        ///     max(SEQ) > N => Invalid prüfer code
+        ///     max(SEQ) > N => Invalid prüfer code"#);
+        /// ```
+        ///
+        /// ```
+        /// # use inverse_prufer::PruferCode;
+        /// let res = PruferCode::try_from([4, 0, 3, 4].as_slice());
+        /// # let res = match res {
+        /// #   Ok(_) => panic!(),
+        /// #   Err(e) => e,
+        /// # };
+        /// assert_eq!(res.to_string(),
+        /// r#"Invalid value in code: 0
+        ///     SEQ = [4, 0, 3, 4]
+        ///     0 ∈ SEQ => Invalid prüfer code"#);
         /// ```
         fn to_string(&self) -> String {
-            let InvalidPruferCode {
-                invalid_value,
-                code,
-            } = *self;
-            format!(
-                r#"Invalid value in code: {invalid_value}
+            match *self {
+                Self::ValueTooLarge {
+                    invalid_value,
+                    code,
+                } => format!(
+                    r#"Invalid value in code: {invalid_value}
     SEQ = {:?}
     N := |SEQ| + 2 = {}
     max(SEQ) = {invalid_value}
     max(SEQ) > N => Invalid prüfer code"#,
-                code,
-                code.len() + 2,
-            )
+                    code,
+                    code.len() + 2,
+                ),
+                Self::ValueIsZero { code } => format!(
+                    r#"Invalid value in code: 0
+    SEQ = {:?}
+    0 ∈ SEQ => Invalid prüfer code"#,
+                    code
+                ),
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,30 @@
+use std::process::ExitCode;
+
 use clap::Parser;
-use inverse_prufer::tree_edges;
+use inverse_prufer::{tree_edges, PruferCode};
 
 #[derive(Parser, Debug)]
 #[command(about, author, version)]
 struct Cli {
     /// Prüfer sequence (example: 4 1 3 4)
-    #[arg(name = "SEQ", required = true, value_delimiter = ' ', value_parser = clap::value_parser!(u64).range(1..))]
+    #[arg(name = "SEQ", required = true, value_delimiter = ' ')]
     code: Vec<u64>,
 }
 
 #[doc(hidden)]
-fn main() {
+fn main() -> ExitCode {
     let args = Cli::parse();
-    let res = tree_edges(&args.code);
-    match res {
-        Ok(edges) => println!("The edge set E(G) is:\n{:?}", &edges),
-        Err(e) => eprintln!("{}", e.to_string()),
+    let code = PruferCode::try_from(args.code.as_slice());
+
+    match code {
+        Ok(code) => {
+            println!("The edge set is:\nE(G) = {:?}", tree_edges(&code));
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("{}", e.to_string());
+            ExitCode::FAILURE
+        }
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,12 +1,15 @@
-use inverse_prufer::{error::InvalidPruferCode, tree_edges};
+use inverse_prufer::{error::InvalidPruferCode, tree_edges, PruferCode};
 
 #[test]
 fn test_prufer_4() {
     const PRUFER_CODE: [u64; 4] = [4, 1, 3, 4];
-    let res = tree_edges(&PRUFER_CODE);
+    let res = PruferCode::try_from(PRUFER_CODE.as_slice());
 
     match res {
-        Ok(edges) => assert_eq!([(2, 4), (5, 1), (1, 3), (3, 4), (4, 6)], edges.as_slice()),
+        Ok(code) => assert_eq!(
+            [(2, 4), (5, 1), (1, 3), (3, 4), (4, 6)],
+            tree_edges(&code).as_slice()
+        ),
         Err(e) => assert!(false, "{}", e.to_string()),
     }
 }
@@ -14,12 +17,12 @@ fn test_prufer_4() {
 #[test]
 fn test_prufer_5() {
     const PRUFER_CODE: [u64; 5] = [5, 1, 2, 4, 3];
-    let res = tree_edges(&PRUFER_CODE);
+    let res = PruferCode::try_from(PRUFER_CODE.as_slice());
 
     match res {
-        Ok(edges) => assert_eq!(
+        Ok(code) => assert_eq!(
             [(6, 5), (5, 1), (1, 2), (2, 4), (4, 3), (3, 7)],
-            edges.as_slice()
+            tree_edges(&code).as_slice()
         ),
         Err(e) => assert!(false, "{}", e.to_string()),
     }
@@ -28,22 +31,39 @@ fn test_prufer_5() {
 #[test]
 fn test_prufer_6() {
     const PRUFER_CODE: [u64; 6] = [1, 1, 1, 1, 6, 5];
-    let res = tree_edges(&PRUFER_CODE);
+    let res = PruferCode::try_from(PRUFER_CODE.as_slice());
 
     match res {
-        Ok(edges) => assert_eq!(
+        Ok(code) => assert_eq!(
             [(2, 1), (3, 1), (4, 1), (7, 1), (1, 6), (6, 5), (5, 8)],
-            edges.as_slice()
+            tree_edges(&code).as_slice()
         ),
         Err(e) => assert!(false, "{}", e.to_string()),
     }
 }
 
 #[test]
-fn test_invalid_code() {
+fn test_invalid_code_large() {
     const WRONG_CODE: u64 = 7;
     const PRUFER_CODE: [u64; 4] = [4, WRONG_CODE, 3, 4];
-    let res = tree_edges(&PRUFER_CODE);
+    let res = PruferCode::try_from(PRUFER_CODE.as_slice());
 
-    assert_eq!(res, Err(InvalidPruferCode::new(WRONG_CODE, &PRUFER_CODE)));
+    assert_eq!(
+        res,
+        Err(InvalidPruferCode::ValueTooLarge {
+            invalid_value: WRONG_CODE,
+            code: &PRUFER_CODE
+        })
+    );
+}
+
+#[test]
+fn test_invalid_code_zero() {
+    const PRUFER_CODE: [u64; 4] = [4, 0, 3, 4];
+    let res = PruferCode::try_from(PRUFER_CODE.as_slice());
+
+    assert_eq!(
+        res,
+        Err(InvalidPruferCode::ValueIsZero { code: &PRUFER_CODE })
+    )
 }


### PR DESCRIPTION
This patch introduces proper error handling when a zero value is given in the Prüfer code. Previous implementation relied on the CLI parser to catch this now, a validation step before the edge set computation catches this and provides a proper error message.

Some other changes:
 - Signal failure or success with `ExitCode` (0|1)
 - Update program output
   - Update README.md accordingly
 - Add new negative test for the new zero value error